### PR TITLE
feat: -carbon.settingdir for override dir with Carbon config file

### DIFF
--- a/src/Utility/Defines.cs
+++ b/src/Utility/Defines.cs
@@ -13,6 +13,7 @@ public class Defines
 	public static void Initialize()
 	{
 		GetRootFolder();
+		GetSettingsFolder();
 		GetConfigsFolder();
 		GetModulesFolder();
 		GetDataFolder();
@@ -24,6 +25,7 @@ public class Defines
 
 	internal static string _customRustRootFolder;
 	internal static string _customRootFolder;
+	internal static string _customSettingFolder;
 	internal static string _customScriptFolder;
 	internal static string _customConfigFolder;
 	internal static string _customDataFolder;
@@ -50,6 +52,7 @@ public class Defines
 		}
 		_customRustRootFolder = "-carbon.rustrootdir".GetArgumentResult();
 		_customRootFolder = "-carbon.rootdir".GetArgumentResult();
+		_customSettingFolder = "-carbon.settingdir".GetArgumentResult();
 		_customScriptFolder = "-carbon.scriptdir".GetArgumentResult();
 		_customConfigFolder = "-carbon.configdir".GetArgumentResult();
 		_customDataFolder = "-carbon.datadir".GetArgumentResult();
@@ -64,23 +67,32 @@ public class Defines
 	public static string GetConfigFile()
 	{
 		_initializeCommandLine();
-		return Path.Combine(GetRootFolder(), "config.json");
+		return Path.Combine(GetSettingsFolder(), "config.json");
 	}
 	public static string GetMonoProfilerConfigFile()
 	{
 		_initializeCommandLine();
-		return Path.Combine(GetRootFolder(), "config.profiler.json");
+		return Path.Combine(GetSettingsFolder(), "config.profiler.json");
 	}
 	public static string GetCarbonAutoFile()
 	{
 		_initializeCommandLine();
-		return Path.Combine(GetRootFolder(), "config.auto.json");
+		return Path.Combine(GetSettingsFolder(), "config.auto.json");
 	}
 
 	public static string GetRootFolder()
 	{
 		_initializeCommandLine();
 		var folder = string.IsNullOrEmpty(_customRootFolder) ? Path.Combine(root, "carbon") : _customRootFolder;
+		Directory.CreateDirectory(folder);
+
+		return folder;
+	}
+	
+	public static string GetSettingsFolder()
+	{
+		_initializeCommandLine();
+		var folder = string.IsNullOrEmpty(_customSettingFolder) ? root : _customRootFolder;
 		Directory.CreateDirectory(folder);
 
 		return folder;


### PR DESCRIPTION
# Description
For now, we cannot move config file of Carbon, but I suggest add new switch `-carbon.settingdir` which override default <root> dir for Carbon Config, Carbon Auto and Carbon Profiler configs

# Example of use

1) Push config file to server Git (if exists) and easily use it
2) Centralized config file (ex. /opt/carbon/config) for reusing on production servers

# Affect 

This feature affects theese repo:


[CarbonCommunity/Carbon.Preloader](https://github.com/CarbonCommunity/Carbon.Preloader)


[CarbonCommunity/Carbon.Bootstrap](https://github.com/CarbonCommunity/Carbon.Bootstrap)


[CarbonCommunity/Carbon.Startup](https://github.com/CarbonCommunity/Carbon.Startup)

[CarbonCommunity/Carbon.Common](https://github.com/CarbonCommunity/Carbon.Common)